### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ module "dcos-forwarding-rule-masters" {
 
   masters_self_link = ["${var.masters_self_link}"]
   additional_rules  = ["${var.masters_additional_rules}"]
+  adminrouter_grpc_proxy_port = "${var.adminrouter_grpc_proxy_port}"
 
   labels = "${var.labels}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,8 @@ variable "disable_public_agents" {
   description = "[PUBLIC AGENTS] Do not create load balancer and its resources"
   default     = false
 }
+
+variable "adminrouter_grpc_proxy_port" {
+  description = ""
+  default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476